### PR TITLE
External-url-open-in-browser

### DIFF
--- a/inject/preload.js
+++ b/inject/preload.js
@@ -3,6 +3,7 @@
   const console = { ...window.console };
   const hookPlayer = require("./player-hook");
   const browser = require("electron").remote.BrowserWindow.getAllWindows()[0];
+  const shell = require('electron').shell
   const discord = require("./integrations/discord");
   const windows = require("./integrations/windows-media");
   const buttons = require("../app/buttons");
@@ -21,4 +22,10 @@
       windows.hook();
     }
   });
+  document.addEventListener('click', function (event) {
+    if (event.target.tagName === 'A' && event.target.href.startsWith('http') && !/(https?:\/\/musik.yousee\.dk(\/[A-Za-z0-9\-\._~:\/\?#\[\]@!$&'\(\)\*\+,;\=]*)?)/.test(event.target.href)) {
+      event.preventDefault()
+      shell.openExternal(event.target.href)
+    }
+  })
 })();


### PR DESCRIPTION
If you for example press on forgot password it's redirecting to id.yousee and then the frame buttons disappear.

This PR will try to solve that with doing a regex to match all URL's if doesn't match with http(s)://musik.yousee.dk/* then it will open in an external browser.